### PR TITLE
Remove redudant method & change implementation to internal

### DIFF
--- a/DK-GenericLibrary/AsyncRepository.cs
+++ b/DK-GenericLibrary/AsyncRepository.cs
@@ -97,17 +97,12 @@ namespace DK.GenericLibrary
 
 
 		/// <inheritdoc/>
-		public async Task<List<T>> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : class
+		public async Task<List<T>> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class 
 		{
 			await using var context = await dbContextFactory.CreateDbContextAsync();
 			return await Task.FromResult(queryOperation(context.Set<TEntity>().AsNoTracking()).ToList());
 		}
-		/// <inheritdoc/>
-		public async Task<List<T>> GetAllItemsStruct<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : struct
-		{
-			await using var context = await dbContextFactory.CreateDbContextAsync();
-			return await Task.FromResult(queryOperation(context.Set<TEntity>().AsNoTracking()).ToList());
-		}
+
 		/// <inheritdoc/>
 		public async Task UpdateItem<TEntity>(TEntity item) where TEntity : class
 		{

--- a/DK-GenericLibrary/AsyncRepository.cs
+++ b/DK-GenericLibrary/AsyncRepository.cs
@@ -2,7 +2,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System.Linq.Expressions;
-
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("RepoUnitTests.AsyncRepoTests")]
 namespace DK.GenericLibrary
 {
 	/// <summary>
@@ -13,7 +14,7 @@ namespace DK.GenericLibrary
 	/// Uses IDbContextFactory to create context instances
 	/// </remarks>
 	/// <param name="dbContextFactory"></param>
-	public class AsyncRepository<TContext>(IDbContextFactory<TContext> dbContextFactory) : IAsyncRepository<TContext> where TContext : DbContext
+	internal class AsyncRepository<TContext>(IDbContextFactory<TContext> dbContextFactory) : IAsyncRepository<TContext> where TContext : DbContext
 	{
 
 

--- a/DK-GenericLibrary/Interfaces/IAsyncRepository.cs
+++ b/DK-GenericLibrary/Interfaces/IAsyncRepository.cs
@@ -112,20 +112,7 @@ namespace DK.GenericLibrary.Interfaces
 		/// <typeparam name="T">Expected return type</typeparam>
 		/// <param name="queryOperation">IQueryable expression</param>
 		/// <returns>List{T}</returns>
-		Task<List<T>> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : class;
-
-		/// <summary>
-		/// Returns T from DbSet matching type parameter.
-		/// <para>Used to retrieve struct data types</para>
-		/// <para>
-		/// <![CDATA[Example: _repository.GetAllForColumn<TEntity, int>(q => q.Select(x => x.PropertyName))]]>
-		/// </para>
-		/// </summary>
-		/// <typeparam name="TEntity"></typeparam>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="queryOperation"></param>
-		/// <returns></returns>
-		Task<List<T>> GetAllItemsStruct<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : struct;
+		Task<List<T>> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class;
 
 		/// <summary>
 		/// Changes TEntity reference and its' collections EntityState to Modified. Note that it will only catch 1 nested collection, anything past that can be put directly as a parameter as ut us a TEntity

--- a/DK-GenericLibrary/Interfaces/IRepository.cs
+++ b/DK-GenericLibrary/Interfaces/IRepository.cs
@@ -97,20 +97,9 @@ namespace DK.GenericLibrary.Interfaces
 		/// <typeparam name="T"></typeparam>
 		/// <param name="queryOperation"></param>
 		/// <returns>List{T}</returns>
-		List<T> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : class;
-		/// <summary>
-		/// Returns T from DbSet matching type parameter.
-		/// <para>Used to retrieve struct data types</para>
-		/// <para>
-		/// <![CDATA[Example: _repository.GetAllForColumn<TEntity, int>(q => q.Select(x => x.PropertyName))]]>
-		/// </para>
-		/// </summary>
-		/// <typeparam name="TEntity"></typeparam>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="queryOperation"></param>
-		/// <returns></returns>
-		List<T> GetAllItemsStruct<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : struct;
+		List<T> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class;
 
+	
 		/// <summary>
 		/// Changes TEntity reference and its' collections EntityState to Modified. Note that it will only catch 1 nested collection, anything past that can be put directly as a parameter as ut us a TEntity
 		/// </summary>

--- a/DK-GenericLibrary/Repository.cs
+++ b/DK-GenericLibrary/Repository.cs
@@ -2,7 +2,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System.Linq.Expressions;
-
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("RepoUnitTests.RepoUnitTests")]
 namespace DK.GenericLibrary
 {
 
@@ -10,7 +11,7 @@ namespace DK.GenericLibrary
 	/// Provides the implementation of the IRepository interface
 	/// </summary>
 	/// <typeparam name="TContext"></typeparam>
-	public class Repository<TContext>(IDbContextFactory<TContext> dbContextFactory) : IRepository<TContext> where TContext : DbContext
+	internal class Repository<TContext>(IDbContextFactory<TContext> dbContextFactory) : IRepository<TContext> where TContext : DbContext
 	{
 
 

--- a/DK-GenericLibrary/Repository.cs
+++ b/DK-GenericLibrary/Repository.cs
@@ -82,17 +82,12 @@ namespace DK.GenericLibrary
 				: context.Set<TEntity>().AsNoTracking().ToList();
 		}
 		/// <inheritdoc/>
-		public List<T> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : class
+		public List<T> GetAllItems<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class 
 		{
 			using var context = dbContextFactory.CreateDbContext();
 			return queryOperation(context.Set<TEntity>().AsNoTracking()).ToList();
 		}
-		/// <inheritdoc/>
-		public List<T> GetAllItemsStruct<TEntity, T>(Func<IQueryable<TEntity>, IQueryable<T>> queryOperation) where TEntity : class where T : struct
-		{
-			using var context = dbContextFactory.CreateDbContext();
-			return queryOperation(context.Set<TEntity>().AsNoTracking()).ToList();
-		}
+
 		/// <inheritdoc/>
 		public void UpdateItem<TEntity>(TEntity item) where TEntity : class
 		{

--- a/RepoUnitTests/AsyncRepoTests.cs
+++ b/RepoUnitTests/AsyncRepoTests.cs
@@ -296,7 +296,7 @@ namespace RepoUnitTests
 			await repository.AddItems(basicClassList);
 
 			List<string> result = await repository.GetAllItems<BasicClass, string>(x => x.Select(s => s.TestField)!);
-			List<int> test2Result = await repository.GetAllItemsStruct<BasicClass, int>(x => x.Select(s => s.Refnr));
+			List<int> test2Result = await repository.GetAllItems<BasicClass, int>(x => x.Select(s => s.Refnr));
 			That(result.Count == 3);
 			That(test2Result.Count == 3 && test2Result.First() == 1);
 		}

--- a/RepoUnitTests/AsyncRepoTests.cs
+++ b/RepoUnitTests/AsyncRepoTests.cs
@@ -7,7 +7,7 @@ using static NUnit.Framework.Assert;
 
 namespace RepoUnitTests
 {
-	public class AsyncRepoTests
+	internal class AsyncRepoTests
 	{
 		private ServiceProvider _serviceProvider;
 

--- a/RepoUnitTests/RepoTests.cs
+++ b/RepoUnitTests/RepoTests.cs
@@ -6,7 +6,7 @@ using static NUnit.Framework.Assert;
 
 namespace RepoUnitTests
 {
-	class RepoTests
+	internal class RepoTests
 	{
 		private ServiceProvider _serviceProvider;
 

--- a/RepoUnitTests/RepoTests.cs
+++ b/RepoUnitTests/RepoTests.cs
@@ -286,7 +286,7 @@ namespace RepoUnitTests
 			repository.AddItems(basicClassList);
 
 			List<string> result = repository.GetAllItems<BasicClass, string>(x => x.Select(s => s.TestField)!);
-			List<int> test2Result = repository.GetAllItemsStruct<BasicClass, int>(x => x.Select(s => s.Refnr));
+			List<int> test2Result = repository.GetAllItems<BasicClass, int>(x => x.Select(s => s.Refnr));
 			That(result.Count == 3);
 			That(test2Result.Count == 3 && test2Result.First() == 1);
 		}

--- a/RepoUnitTests/RepoUnitTests.csproj
+++ b/RepoUnitTests/RepoUnitTests.csproj
@@ -1,38 +1,38 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="DK.GenericLibrary">
-      <HintPath>C:\actions-runner\DK.GenericLibrary.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+	<ItemGroup>
+		<Reference Include="DK.GenericLibrary">
+			<HintPath>C:\actions-runner\DK.GenericLibrary.dll</HintPath>
+		</Reference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Using Include="NUnit.Framework" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="NUnit.Framework" />
+	</ItemGroup>
 
 </Project>

--- a/RepoUnitTests/RepoUnitTests.csproj
+++ b/RepoUnitTests/RepoUnitTests.csproj
@@ -26,9 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="DK.GenericLibrary">
-			<HintPath>C:\actions-runner\DK.GenericLibrary.dll</HintPath>
-		</Reference>
+	  <ProjectReference Include="..\DK-GenericLibrary\DK-GenericLibrary.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/RepoUnitTests/TestServiceProvider.cs
+++ b/RepoUnitTests/TestServiceProvider.cs
@@ -10,7 +10,7 @@ namespace RepoUnitTests
 	/// <summary>
 	/// Static class to provide a service provider for testing
 	/// </summary>
-	public static class TestServiceProvider
+	internal static class TestServiceProvider
 	{
 
 		/// <summary>
@@ -29,7 +29,7 @@ namespace RepoUnitTests
 
 			//Datetime wasn't enough to make sure they had different names, so random was added
 			services.AddDbContextFactory<FakeContext>(options =>
-				options.UseInMemoryDatabase("TestDatabase" + DateTime.Now + random.Next(1, 500)));
+				options.UseInMemoryDatabase("TestDatabase" + Guid.NewGuid()));
 			return services.BuildServiceProvider();
 		}
 
@@ -47,7 +47,7 @@ namespace RepoUnitTests
 				services.AddScopedRepository<FakeContext>();
 			//Datetime wasn't enough to make sure they had different names, so random was added
 			services.AddDbContextFactory<FakeContext>(options =>
-				options.UseInMemoryDatabase("TestDatabase" + DateTime.Now + random.Next(1, 500)));
+				options.UseInMemoryDatabase("TestDatabase" + Guid.NewGuid()));
 			return services.BuildServiceProvider();
 		}
 
@@ -66,7 +66,7 @@ namespace RepoUnitTests
 				services.AddSingletonRepository<FakeContext>();
 			//Datetime wasn't enough to make sure they had different names, so random was added
 			services.AddDbContextFactory<FakeContext>(options =>
-				options.UseInMemoryDatabase("TestDatabase" + DateTime.Now + random.Next(1, 500)));
+				options.UseInMemoryDatabase("TestDatabase" + Guid.NewGuid()));
 			return services.BuildServiceProvider();
 		}
 

--- a/TestService/Program.cs
+++ b/TestService/Program.cs
@@ -15,9 +15,9 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddTransient<RepoTestService>();
 builder.Services.AddTransient<AsyncRepoTestService>();
 
-builder.Services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
+builder.Services.AddTransient(typeof(IRepository<>));
 
-builder.Services.AddTransient(typeof(IAsyncRepository<>), typeof(AsyncRepository<>));
+builder.Services.AddTransient(typeof(IAsyncRepository<>));
 builder.Services.AddDbContextFactory<TestContext>();
 
 


### PR DESCRIPTION
The class constraint broke GetAllItems when dealing with structs, so I made 2 methods, that's not necessary so it's removed again.

Also changing the implementation to internal to encourage use of interfaces going forward